### PR TITLE
Show ux version

### DIFF
--- a/src/components/VersionItem.vue
+++ b/src/components/VersionItem.vue
@@ -6,7 +6,7 @@ store.getVersion();
 
 <template>
   <span v-if="store.version" id="version-string">
-    version {{ store.version.version }}
+    v{{ store.version.version }}
   </span>
   <span v-else>loading ...</span>
 </template>

--- a/src/views/MenuView.vue
+++ b/src/views/MenuView.vue
@@ -25,9 +25,10 @@
         </RouterLink>
         <MenuMain />
         <span class="grow"></span>
-        <span class="my-3 text-sm" id="version"
-          >collectivo — <VersionItem
-        /></span>
+        <span class="p-4 text-xs w-full text-gray-800" id="version">
+          collectivo <VersionItem/> <br/>
+          collectivo-ux v{{ version }}
+        </span>
       </div>
     </div>
   </div>
@@ -38,6 +39,7 @@ import MenuMain from "../components/MenuMain.vue";
 import VersionItem from "../components/VersionItem.vue";
 import { useMenuStore } from "../stores/menu";
 import { storeToRefs } from "pinia";
+import { version } from "../../package.json";
 const menuStore = useMenuStore();
 const { getSideBarOpen } = storeToRefs(menuStore);
 function toggleSideBar() {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,6 +1,6 @@
 {
   "extends": "@vue/tsconfig/tsconfig.web.json",
-  "include": ["env.d.ts", "src/**/*", "src/**/*.vue", "src/**/*.json"],
+  "include": ["package.json", "env.d.ts", "src/**/*", "src/**/*.vue", "src/**/*.json"],
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
The version of collectivo-ux is now also shown in the bottom left corner of the application.