### PR TITLE
Add email automations tab

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -85,6 +85,7 @@ export const endpoints = {
   membersEmailsDesigns: "/members/emails/designs/",
   membersEmailsTemplates: "/members/emails/templates/",
   membersEmailsCampaigns: "/members/emails/campaigns/",
+  membersEmailsAutomations: "/members/emails/automations/",
 };
 
 // Generic API functions

--- a/src/components/datatable/ObjectLoader.vue
+++ b/src/components/datatable/ObjectLoader.vue
@@ -16,6 +16,10 @@ const props = defineProps({
     type: String as PropType<keyof typeof endpoints>,
     required: true,
   },
+  defaultColumns: {
+    type: Array as PropType<string[]>,
+    required: false,
+  },
 });
 
 const error = ref<Object | null>(null);
@@ -37,11 +41,7 @@ if (!data.value.loaded) {
     <PrimeProgressSpinner />
   </div>
   <div v-else class="h-full">
-    <ObjectTableFrame
-      :store="store"
-      :name="name"
-      :objects="data.data"
-      :schema="data.schema"
-    />
+    <ObjectTableFrame :store="store" :name="name" :objects="data.data"
+      :schema="data.schema" :default-columns="defaultColumns" />
   </div>
 </template>

--- a/src/components/datatable/ObjectTableFrame.vue
+++ b/src/components/datatable/ObjectTableFrame.vue
@@ -34,6 +34,10 @@ const props = defineProps({
     type: Object,
     required: true,
   },
+  defaultColumns: {
+    type: Array as PropType<string[]>,
+    required: false,
+  },
 });
 
 // Filter functions (match modes) ------------------------------------------ //
@@ -82,8 +86,9 @@ for (const [key, value] of Object.entries(props.schema)) {
 }
 
 // Set default columns
-// TODO: Load default columns from schema
-const defaultColumns = ["sent", "name", "label", "status", "template", "design", "body"];
+const defaultColumns = props.defaultColumns
+  ? props.defaultColumns
+  : ["id", "name", "label", "status"];
 for (const col of defaultColumns) {
   if (!columns.find((c) => c.field === col)) {
     continue;
@@ -113,7 +118,6 @@ function createObjectFn() {
 
 <template>
   <div class="flex flex-col h-full bg-white">
-
     <!-- Toolbar -->
     <PrimeToolbar class="mb-4">
       <template #start>
@@ -183,7 +187,6 @@ function createObjectFn() {
         v-model:editCreate="editCreate"
       />
     </div>
-
   </div>
 
   <!-- Detail dialog -->
@@ -196,5 +199,4 @@ function createObjectFn() {
     :schema="schema"
     @close="editActive = false"
   />
-
 </template>

--- a/src/components/members/MembersEmails.vue
+++ b/src/components/members/MembersEmails.vue
@@ -22,6 +22,9 @@ menuStore.setTitle("Member Emails");
       <TabPanel header="Designs">
         <ObjectLoader :store="membersStore" :name="'membersEmailsDesigns'" />
       </TabPanel>
+      <TabPanel header="Automations">
+        <ObjectLoader :store="membersStore" :name="'membersEmailsAutomations'" />
+      </TabPanel>
     </TabView>
   </div>
 </template>

--- a/src/components/members/MembersEmails.vue
+++ b/src/components/members/MembersEmails.vue
@@ -9,21 +9,36 @@ const membersStore = useMembersStore();
 const menuStore = useMenuStore();
 menuStore.setTitle("Member Emails");
 </script>
-
 <template>
   <div class="h-full tabview-full">
     <TabView lazy>
       <TabPanel header="Campaigns">
-        <ObjectLoader :store="membersStore" :name="'membersEmailsCampaigns'" />
+        <ObjectLoader
+          :store="membersStore"
+          :name="'membersEmailsCampaigns'"
+          :defaultColumns="['status', 'template', 'recipients', 'automation']"
+        />
       </TabPanel>
       <TabPanel header="Templates">
-        <ObjectLoader :store="membersStore" :name="'membersEmailsTemplates'" />
+        <ObjectLoader
+          :store="membersStore"
+          :name="'membersEmailsTemplates'"
+          :defaultColumns="['name', 'subject', 'design']"
+        />
       </TabPanel>
       <TabPanel header="Designs">
-        <ObjectLoader :store="membersStore" :name="'membersEmailsDesigns'" />
+        <ObjectLoader
+          :store="membersStore"
+          :name="'membersEmailsDesigns'"
+          :defaultColumns="['name', 'body']"
+        />
       </TabPanel>
       <TabPanel header="Automations">
-        <ObjectLoader :store="membersStore" :name="'membersEmailsAutomations'" />
+        <ObjectLoader
+          :store="membersStore"
+          :name="'membersEmailsAutomations'"
+          :defaultColumns="['trigger', 'template']"
+        />
       </TabPanel>
     </TabView>
   </div>

--- a/src/stores/members.ts
+++ b/src/stores/members.ts
@@ -12,11 +12,12 @@ type membersStore = {
   membersEmailsCampaigns: DataList;
   membersEmailsTemplates: DataList;
   membersEmailsDesigns: DataList;
+  membersEmailsAutomations: DataList;
 };
 
 type membersObject = keyof membersStore;
 
-function extendSchema(schema:any) {
+function extendSchema(schema: any) {
   // Transform choices dict into an options list
   for (const value of Object.values(schema) as any) {
     if (value.choices == undefined) {
@@ -40,16 +41,17 @@ function extendSchema(schema:any) {
 export const useMembersStore = defineStore({
   id: "members",
   state: () =>
-    ({
-      membersMembers: JSON.parse(JSON.stringify(DataDetailTemplate)),
-      membersSummary: JSON.parse(JSON.stringify(DataListTemplate)),
-      membersProfile: JSON.parse(JSON.stringify(DataDetailTemplate)),
-      membersRegister: JSON.parse(JSON.stringify(DataDetailTemplate)),
-      membersTags: JSON.parse(JSON.stringify(DataListTemplate)),
-      membersEmailsCampaigns: JSON.parse(JSON.stringify(DataListTemplate)),
-      membersEmailsTemplates: JSON.parse(JSON.stringify(DataListTemplate)),
-      membersEmailsDesigns: JSON.parse(JSON.stringify(DataListTemplate)),
-    } as membersStore),
+  ({
+    membersMembers: JSON.parse(JSON.stringify(DataDetailTemplate)),
+    membersSummary: JSON.parse(JSON.stringify(DataListTemplate)),
+    membersProfile: JSON.parse(JSON.stringify(DataDetailTemplate)),
+    membersRegister: JSON.parse(JSON.stringify(DataDetailTemplate)),
+    membersTags: JSON.parse(JSON.stringify(DataListTemplate)),
+    membersEmailsCampaigns: JSON.parse(JSON.stringify(DataListTemplate)),
+    membersEmailsTemplates: JSON.parse(JSON.stringify(DataListTemplate)),
+    membersEmailsDesigns: JSON.parse(JSON.stringify(DataListTemplate)),
+    membersEmailsAutomations: JSON.parse(JSON.stringify(DataListTemplate)),
+  } as membersStore),
 
   actions: {
     async get(objectName: membersObject, pk?: Number) {

--- a/src/stores/members.ts
+++ b/src/stores/members.ts
@@ -35,23 +35,23 @@ function extendSchema(schema: any) {
       });
     }
   }
-  return schema
+  return schema;
 }
 
 export const useMembersStore = defineStore({
   id: "members",
   state: () =>
-  ({
-    membersMembers: JSON.parse(JSON.stringify(DataDetailTemplate)),
-    membersSummary: JSON.parse(JSON.stringify(DataListTemplate)),
-    membersProfile: JSON.parse(JSON.stringify(DataDetailTemplate)),
-    membersRegister: JSON.parse(JSON.stringify(DataDetailTemplate)),
-    membersTags: JSON.parse(JSON.stringify(DataListTemplate)),
-    membersEmailsCampaigns: JSON.parse(JSON.stringify(DataListTemplate)),
-    membersEmailsTemplates: JSON.parse(JSON.stringify(DataListTemplate)),
-    membersEmailsDesigns: JSON.parse(JSON.stringify(DataListTemplate)),
-    membersEmailsAutomations: JSON.parse(JSON.stringify(DataListTemplate)),
-  } as membersStore),
+    ({
+      membersMembers: JSON.parse(JSON.stringify(DataDetailTemplate)),
+      membersSummary: JSON.parse(JSON.stringify(DataListTemplate)),
+      membersProfile: JSON.parse(JSON.stringify(DataDetailTemplate)),
+      membersRegister: JSON.parse(JSON.stringify(DataDetailTemplate)),
+      membersTags: JSON.parse(JSON.stringify(DataListTemplate)),
+      membersEmailsCampaigns: JSON.parse(JSON.stringify(DataListTemplate)),
+      membersEmailsTemplates: JSON.parse(JSON.stringify(DataListTemplate)),
+      membersEmailsDesigns: JSON.parse(JSON.stringify(DataListTemplate)),
+      membersEmailsAutomations: JSON.parse(JSON.stringify(DataListTemplate)),
+    } as membersStore),
 
   actions: {
     async get(objectName: membersObject, pk?: Number) {


### PR DESCRIPTION
Frontend implementation of https://github.com/MILA-Wien/collectivo/pull/71

- Add email automations to API and members store
- Add a new tab and datatable for automations in the emails section 
- Pass default columns as a prop to ObjectLoader.vue